### PR TITLE
Fix/port names

### DIFF
--- a/ControlPlugin/src/ControlPlugin.cpp
+++ b/ControlPlugin/src/ControlPlugin.cpp
@@ -83,7 +83,7 @@ void gazebo::ControlPlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf)
     }
 
     /* Open RPC port and attach to respond handler. */
-    if (!port_rpc_.open(rpc_port_name + "/rpc:i"))
+    if (!port_rpc_.open(rpc_port_name))
     {
         yError() << "At line " << __LINE__ << ", in function " << __FUNCTION__ << ", cannot open rpc port. Closing the plugin thread.";
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ The following snippet shows how to declare the ControlPlugin
 <plugin name="ControlPlugin" filename="libControlPlugin.so">
     <Gain>10</Gain>
     <Link>link_name</Link>
-    <PortOutputPoseName>name_of_the_output_port</PortOutputPoseName>
-    <PortRpcName>name_of_the_rpc_port</PortRpcName>
+    <PortOutputPoseName>/name/of/the/output/port</PortOutputPoseName>
+    <PortRpcName>/name/of/the/rpc/port</PortRpcName>
 </plugin>
 ```
 The `Link` parameter indicates the name of the link that is controlled.  

--- a/models/left_hand_mk3_one_sensor/model.urdf
+++ b/models/left_hand_mk3_one_sensor/model.urdf
@@ -378,7 +378,7 @@
     <plugin name="ControlPlugin" filename="libControlPlugin.so">
         <Gain> 10 </Gain>
         <Link>SIM_LEFT_HAND::l_hand_palm_link</Link>
-        <PortRpcName>control-hand-port</PortRpcName>
+        <PortRpcName>/control-hand-port/rpc:i</PortRpcName>
         <PortOutputPoseName>/port-real-time-pose/output:o</PortOutputPoseName>
     </plugin>
     </gazebo>

--- a/models/left_hand_mk3_three_sensors/model.urdf
+++ b/models/left_hand_mk3_three_sensors/model.urdf
@@ -405,7 +405,7 @@
     <plugin name="ControlPlugin" filename="libControlPlugin.so">
         <Gain> 10 </Gain>
         <Link>SIM_LEFT_HAND::l_hand_palm_link</Link>
-        <PortRpcName>control-hand-port</PortRpcName>
+        <PortRpcName>/control-hand-port/rpc:i</PortRpcName>
         <PortOutputPoseName>/port-real-time-pose/output:o</PortOutputPoseName>
     </plugin>
     </gazebo>


### PR DESCRIPTION
This PR standardizes the way `YARP` port names are handled in the `ControlPlugin` plugin.

I.e., at the moment
- for `PortOutputPoseName` the plugin is using the full name provided by the user
- for `PortRpcName`  the plugin composes the port name as `<what_is_provided_by_the_user>/rpc:i`.

With the PR, also the second port is handled as the first one, in order to have a similar behavior.

It also changes the `README` in order to make explicit the fact that the port has to start with a leading `/`.