### PR TITLE
Add RPC methods SetStatic{Pose, Position, Orientation}

### DIFF
--- a/ControlPlugin/src/ControlPlugin.h
+++ b/ControlPlugin/src/ControlPlugin.h
@@ -28,7 +28,7 @@ namespace gazebo
 
 
 class gazebo::ControlPlugin : public ModelPlugin,
-                                  public SetNewPoseIDL
+                              public SetNewPoseIDL
 {
     public:
 
@@ -56,8 +56,14 @@ class gazebo::ControlPlugin : public ModelPlugin,
 
         std::string NewRelativeOrientation(const double axis_x, const double axis_y, const double axis_z, const double angle, const std::string& fixed_axes, const double duration) override;
 
+        std::string SetStaticPose(const double x, const double y, const double z, const double axis_x, const double axis_y, const double axis_z, const double angle) override;
+
+        std::string SetStaticPosition(const double x, const double y, const double z) override;
+
+        std::string SetStaticOrientation(const double axis_x, const double axis_y, const double axis_z, const double angle) override;
+
         std::string GoHome() override;
-        
+
         std::string SetControlStatus(const std::string& status);
 
     private:
@@ -79,7 +85,7 @@ class gazebo::ControlPlugin : public ModelPlugin,
 
         /* Flag to handle the first cycle. */
         bool is_motion_done_ = false;
-        
+
         /* Flag to handle control status */
         bool is_control_on_ = true;
 

--- a/ControlPlugin/thrift/idl.thrift
+++ b/ControlPlugin/thrift/idl.thrift
@@ -17,7 +17,13 @@ service SetNewPoseIDL
 
     string NewRelativeOrientation(1: double axis_x, 2: double axis_y, 3: double axis_z, 4: double angle, 5: string fixed_axes, 6: double duration);
 
+    string SetStaticPose(1: double x, 2: double y, 3: double z, 4: double axis_x, 5: double axis_y, 6: double axis_z, 7: double angle);
+
+    string SetStaticPosition(1: double x, 2: double y, 3: double z);
+
+    string SetStaticOrientation(1: double axis_x, 2: double axis_y, 3: double axis_z, 4: double angle);
+
     string GoHome();
-    
+
     string SetControlStatus(1: string status);
 }

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ The following snippet shows how to declare the RendererDigitPlugin
     <UpdatePeriod>s</UpdatePeriod>
 </plugin>
 ```
-The `ObjectName` parameter is the name of the object the sensors are sensitive to.  
-The `ObjectMeshAbsolutePath` parameter is the path of the mesh of the object.  
-The `NumberOfSensors` parameter indicates the number of sensors in the model.  
-The `LinkName` and `SensorName` parameters indicate the name of the links and sensors attached to them.  
+The `ObjectName` parameter is the name of the object the sensors are sensitive to.
+The `ObjectMeshAbsolutePath` parameter is the path of the mesh of the object.
+The `NumberOfSensors` parameter indicates the number of sensors in the model.
+The `LinkName` and `SensorName` parameters indicate the name of the links and sensors attached to them.
 The `UpdatePeriod` parameters indicates the sleep time of the rendering thread in seconds.
 
 
@@ -114,7 +114,7 @@ The following snippet shows how to declare the ControlPlugin
     <PortRpcName>/name/of/the/rpc/port</PortRpcName>
 </plugin>
 ```
-The `Link` parameter indicates the name of the link that is controlled.  
+The `Link` parameter indicates the name of the link that is controlled.
 The `PortOutputPoseName` and `PortRpcName` indicates the names of the port which outputs the real time pose of the link and the name of the rpc port to send command to.
 
 At the moment, the urdf snippet code is not available.


### PR DESCRIPTION
As per the title, this PR implements three new RPC methods
- `SetStaticPose`
- `SetStaticPosition`
- `SetStaticOrientation`

allowing to set the pose of the object (or its position or its orientation) kinematically without making use of the dynamic controller (which is disabled after each of these requests).

The user can always re-enable the controller using the RPC call `SetControllerStatus "true"`.